### PR TITLE
Bumping to 1.8.0

### DIFF
--- a/atom/PKGBUILD
+++ b/atom/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Nicola Squartini <tensor5@gmail.com>
 
 pkgname=atom
-pkgver=1.7.4
-pkgrel=2
+pkgver=1.8.0
+pkgrel=1
 pkgdesc='A hackable text editor for the 21st Century'
 arch=('i686' 'x86_64')
 url='https://github.com/atom/atom'
@@ -19,7 +19,7 @@ source=("https://github.com/atom/atom/archive/v${pkgver}.tar.gz"
         'run-as-node.patch'
         'use-system-apm.patch'
         'use-system-electron.patch')
-sha256sums=('6ef3bb4c2fea85a7d1c7665fef8aac4e353c8f8da5e2878fea3aecf5437383d4'
+sha256sums=('2950820b2c7ab658135e9cb7c003ff2074ec0a38ac3b324d85cc20bcb237e61f'
             'e92e23bbf839bec6611b2ac76c1f5bba35b476983b0faa9b310288e2956247a2'
             'd70c4b06631dd451f020366c834d3102cea6837c2e935e66840e0aca3654cea2'
             'ac409d709fd1090fda93b6e575cf46f866d1f9f914a48ea94eb01af3d5c02b9e'


### PR DESCRIPTION
Hi,

I have tested this change and it seems like bumping pkgver to Atom 1.8.0 is good enough. APM's latest ver is 1.11.1 and is more complicated to update. When I updated it and tried to build Atom 1.8.0 against it I got the error: 

```bash
==> Removing existing $pkgdir/ directory...
==> Starting build()...
module.js:442
    throw err;
    ^

Error: Cannot find module 'node-gyp/bin/node-gyp'
    at Function.Module._resolveFilename (module.js:440:15)
    at Function.resolve (internal/module.js:27:19)
    at new Install (/usr/lib/node_modules/atom-package-manager/lib/install.js:53:38)
    at Object.module.exports.run (/usr/lib/node_modules/atom-package-manager/lib/apm-cli.js:226:18)
    at Object.<anonymous> (/usr/lib/node_modules/atom-package-manager/bin/apm:11:6)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
==> ERROR: A failure occurred in build().
    Aborting...
```

Thanks for your time,
Brenton