### PR TITLE
Rename nodejs-atom-package-manager to apm

### DIFF
--- a/apm/PKGBUILD
+++ b/apm/PKGBUILD
@@ -1,15 +1,17 @@
 # Maintainer: Nicola Squartini <tensor5@gmail.com>
 
-pkgname=nodejs-atom-package-manager
+pkgname=apm
 pkgver=1.12.3
 pkgrel=1
 pkgdesc='Atom package manager'
 arch=('i686' 'x86_64')
 url='https://github.com/atom/apm'
 license=('MIT')
-groups=('atom')
 depends=('libgnome-keyring' 'npm' 'python2')
 makedepends=('coffee-script' 'git')
+provides=('nodejs-atom-package-manager')
+conflicts=('nodejs-atom-package-manager')
+replaces=('nodejs-atom-package-manager')
 options=(!emptydirs)
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/atom/apm/archive/v${pkgver}.tar.gz"
         'apm.js'

--- a/atom/PKGBUILD
+++ b/atom/PKGBUILD
@@ -7,8 +7,8 @@ pkgdesc='A hackable text editor for the 21st Century'
 arch=('i686' 'x86_64')
 url='https://github.com/atom/atom'
 license=('MIT' 'custom')
-depends=('electron'
-         'nodejs-atom-package-manager')
+depends=('apm'
+         'electron')
 makedepends=('git' 'npm')
 conflicts=('atom-editor' 'atom-editor-bin' 'atom-editor-git')
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/atom/atom/archive/v${pkgver}.tar.gz"


### PR DESCRIPTION
I think that apm can be considered a stand-alone command line application rather than a library, so we can simply call it as apm. Also remove it from the atom group.

Currently we have the following naming conventions:
> For libraries, use nodejs-$npmname. For applications, use the program name. In either case, the name should be entirely lowercase.

_(Based on the naming conventions for [python](https://wiki.archlinux.org/index.php/Python_package_guidelines#Package_naming) and [ruby](https://wiki.archlinux.org/index.php/Ruby_Gem_package_guidelines#Package_naming).)_