### PR TITLE
Remove only appveyor.yml files, not all .yml

### DIFF
--- a/apm/PKGBUILD
+++ b/apm/PKGBUILD
@@ -75,7 +75,7 @@ package() {
       -or -path "*/keytar/src" -prune -exec rm -r '{}' \; \
       -or -path "*/oniguruma/binding.gyp" -exec rm '{}' \; \
       -or -path "*/oniguruma/src" -prune -exec rm -r '{}' \; \
-      -or -name "*.yml" -exec rm '{}' \; \
+      -or -name "appveyor.yml" -exec rm '{}' \; \
       -or -name "benchmark" -prune -exec rm -r '{}' \; \
       -or -name "binding.Makefile" -exec rm '{}' \; \
       -or -name "config.gypi" -exec rm '{}' \; \


### PR DESCRIPTION
I think that removing all yml files is too risky, as it's a general text format which usually stores settings. Instead of that, just remove appveyor.yml files, which are definitely not used on Linux.