### PR TITLE
Use system coffee to compile coffee scripts

### DIFF
--- a/apm/PKGBUILD
+++ b/apm/PKGBUILD
@@ -9,7 +9,7 @@ url='https://github.com/atom/apm'
 license=('MIT')
 groups=('atom')
 depends=('libgnome-keyring' 'nodejs' 'python2')
-makedepends=('git' 'npm')
+makedepends=('coffee-script' 'git' 'npm')
 options=(!emptydirs)
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/atom/apm/archive/v${pkgver}.tar.gz"
         'apm.js'
@@ -38,8 +38,7 @@ prepare() {
 build() {
   cd apm-${pkgver}
 
-  npm install coffee-script@1.8.0
-  node_modules/.bin/coffee -c --no-header -o lib src/*.coffee
+  coffee -c --no-header -o lib src/*.coffee
   npm install --user root -g --prefix="${srcdir}"/apm-build/usr
 
   cd "${srcdir}/apm-build${_apmdir}"


### PR DESCRIPTION
What do you think? Could we use coffee that is installed on the system? Apparently the compiled files are a bit different, but hopefully it doesn't affect the functionality.